### PR TITLE
fix: replaceAllObjects

### DIFF
--- a/src/searchindex.ts
+++ b/src/searchindex.ts
@@ -37,9 +37,8 @@ export const updateIndex = async () => {
 			],
 			attributesToSnippet: ['*:25']
 		};
-		await index.clearObjects();
 		const { taskID } = await index.setSettings(settings);
 		await index.waitTask(taskID);
-		return index.saveObjects(documents).wait();
+		return index.replaceAllObjects(documents).wait();
 	}
 };


### PR DESCRIPTION
This was a classic "Read the f** manual": There was already a dedicated
API request in Algolia which does exactly what we want.

For us this means the procedure is **atomic** meaning, the index is
either successfully replaced or nothing happened. There is no more
in-between state, ie. the index is deleted.
