### PR TITLE
fix: don't show `false` on initial page load

### DIFF
--- a/src/lib/components/Header/Header.svelte
+++ b/src/lib/components/Header/Header.svelte
@@ -47,7 +47,7 @@
 					<input
 						type="search"
 						name="query"
-						value={(!prerendering && $page.url.searchParams.get('q')) ?? ''}
+						value={(!prerendering && $page.url.searchParams.get('q')) || ''}
 						class="form-control relative flex-auto min-w-0 block w-full max-w-sm px-3 py-2 font-normal bg-white bg-clip-padding peer border-y border-l border-gray-400 rounded-none transition ease-in-out m-0 focus:text-gray-700 focus:bg-white focus:border-black focus:outline-none"
 						placeholder="Suchen"
 						aria-label="Search"


### PR DESCRIPTION
This fixes a minor bug in production where you would see `false` in the
search bar for a few seconds.

I didn't know that "null coalescing operator" `??` only coaleses `null` and
`undefined`, not `false`. So, during prerendering, the left hand side
will be `false`, thus the whole expression is `false`. In the template it will
be rendered as string `"false"`.
