### PR TITLE
refactor: simply remove `en` locale

### DIFF
--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -1,5 +1,4 @@
 export const locales = [
-	{ code: 'en', label: 'EN', importFunction: () => import('$lib/i18n/en.json') },
 	{ code: 'de', label: 'DE', importFunction: () => import('$lib/i18n/de.json') }
 ];
 export const localeCodes = locales.map(({ code }) => code);

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,7 +12,7 @@ const config = {
 		prerender: {
 			default: true,
 			crawl: true,
-			entries: ['*', '/en', '/de']
+			entries: ['*', '/de']
 		}
 	}
 };


### PR DESCRIPTION
Rhenania is currently unable to translate their pages, so we remove it
for now.
