### PR TITLE
feat: clean up temporary indices

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,5 @@
 import { dev } from '$app/environment';
-import { updateIndex } from './searchindex';
+import { updateIndex, cleanTemporaryIndices } from './searchindex';
 
 import type { ServerInit } from '@sveltejs/kit';
 
@@ -7,8 +7,8 @@ export const init: ServerInit = async () => {
 	if (dev) return;
 
 	try {
-		const savedObjects = await updateIndex();
-		console.log('Successfully updated search index.', savedObjects);
+		await updateIndex();
+		await cleanTemporaryIndices();
 	} catch (error) {
 		const message = error instanceof Error ? error.message : error;
 		console.error(message);

--- a/src/lib/algolia.ts
+++ b/src/lib/algolia.ts
@@ -1,5 +1,6 @@
 import { algoliasearch } from 'algoliasearch';
 import { ALGOLIA_APP_ID, ALGOLIA_ADMIN_KEY } from '$lib/env';
 
-export const client = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_ADMIN_KEY);
+export const client =
+	ALGOLIA_APP_ID && ALGOLIA_ADMIN_KEY ? algoliasearch(ALGOLIA_APP_ID, ALGOLIA_ADMIN_KEY) : null;
 export const INDEX = 'rhenania-de';

--- a/src/searchindex.ts
+++ b/src/searchindex.ts
@@ -1,44 +1,67 @@
-import { ALGOLIA_APP_ID, ALGOLIA_ADMIN_KEY } from './lib/env';
 import { SEARCH } from './lib/graphql/queries';
 import { api } from '$lib/graphql/api';
 import { client, INDEX } from './lib/algolia';
+import util from 'util';
 
-const appId = ALGOLIA_APP_ID;
-const apiKey = ALGOLIA_ADMIN_KEY;
+import type { MultipleBatchRequest } from 'algoliasearch';
+
+export const cleanTemporaryIndices = async () => {
+	if (!client) {
+		return;
+	}
+	const indexList = await client.listIndices();
+	const temporaryIndices = indexList.items.filter((index) => {
+		return index.name.startsWith(`${INDEX}_tmp_`) && index.pendingTask === false;
+	});
+	if (temporaryIndices.length > 0) {
+		const requests: MultipleBatchRequest[] = temporaryIndices.map((index) => ({
+			action: 'delete',
+			indexName: index.name
+		}));
+		await client.multipleBatch({ requests: requests });
+		console.log('Deleted these temporary indices without pending task:');
+		console.log(util.inspect(requests, { showHidden: false, depth: null, colors: true }));
+	}
+};
 
 export const updateIndex = async () => {
-	// only update Algolia indices if required env vars are defined
-	if (appId && apiKey) {
-		const { body } = await api(SEARCH, { params: { lang: 'de' } });
-		const { pages, blogPosts } = body.data;
-		const documents = [...pages, ...blogPosts].map((document) => ({
-			...document,
-			objectID: document.id
-		}));
-
-		const settings = {
-			searchableAttributes: [
-				'title',
-				'description',
-				'blogpostTitle',
-				'blogpostMetaDescription',
-				'teaserHeadline',
-				'teaserSubheadline',
-				'teaserText',
-				'modules.headline',
-				'modules.heading1',
-				'modules.heading2',
-				'modules.heading3',
-				'modules.text.html',
-				'modules.accordionItems.headline',
-				'modules.accordionItems.content.html',
-				'modules.cards.headline',
-				'modules.cards.subheadline'
-			],
-			attributesToSnippet: ['*:25']
-		};
-		const { taskID } = await client.setSettings({ indexName: INDEX, indexSettings: settings });
-		await client.waitForTask({ indexName: INDEX, taskID });
-		return client.replaceAllObjects({ indexName: INDEX, objects: documents });
+	if (!client) {
+		// only update Algolia indices if required env vars are defined
+		return;
 	}
+
+	const { body } = await api(SEARCH, { params: { lang: 'de' } });
+	const { pages, blogPosts } = body.data;
+	const documents = [...pages, ...blogPosts].map((document) => ({
+		...document,
+		objectID: document.id
+	}));
+
+	const settings = {
+		searchableAttributes: [
+			'title',
+			'description',
+			'blogpostTitle',
+			'blogpostMetaDescription',
+			'teaserHeadline',
+			'teaserSubheadline',
+			'teaserText',
+			'modules.headline',
+			'modules.heading1',
+			'modules.heading2',
+			'modules.heading3',
+			'modules.text.html',
+			'modules.accordionItems.headline',
+			'modules.accordionItems.content.html',
+			'modules.cards.headline',
+			'modules.cards.subheadline'
+		],
+		attributesToSnippet: ['*:25']
+	};
+	const { taskID } = await client.setSettings({ indexName: INDEX, indexSettings: settings });
+	await client.waitForTask({ indexName: INDEX, taskID });
+	const savedObjects = await client.replaceAllObjects({ indexName: INDEX, objects: documents });
+	console.log('Successfully updated search index:');
+	console.log(util.inspect(savedObjects, { showHidden: false, depth: null, colors: true }));
+	return savedObjects;
 };


### PR DESCRIPTION
We observe leftover temporary indices from [#replaceAllObjects](https://www.algolia.com/doc/libraries/javascript/v5/helpers/#replace-all-records) in algolia.

I don't know why this happens. I'm not able to reproduce this. Maybe because of concurrent write operations?

This PR will clean up temporary indices after the `replaceAllObjects` has been successful.